### PR TITLE
chore(deps): bump vite to ^7.3.2 to close 3 advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-app",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-app",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.8",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.0",
         "@tauri-apps/api": "^2",
@@ -52,7 +52,7 @@
         "shadcn": "^3.8.5",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4",
+        "vite": "^7.3.2",
         "vitest": "^4.0.18",
         "webdriverio": "^9.24.0"
       }
@@ -12234,9 +12234,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12256,9 +12256,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -14708,9 +14708,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "shadcn": "^3.8.5",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4",
+    "vite": "^7.3.2",
     "vitest": "^4.0.18",
     "webdriverio": "^9.24.0"
   }


### PR DESCRIPTION
## Summary

Bumps `vite` from `^7.0.4` to `^7.3.2` to close 3 advisories surfaced by `npm audit --omit=dev`.

| Package | Before → After | Advisories closed |
|---|---|---|
| `vite` | 7.3.1 → 7.3.2 | GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583 |
| `picomatch` | 4.0.3 → 4.0.4 (transitive) | GHSA-3v7f-55p6-f55p, GHSA-c2c7-rcm5-vvqj |
| `postcss` | 8.5.6 → 8.5.12 (transitive) | GHSA-qx2v-qp2m-jg93 |

After this change: `npm audit --omit=dev` reports **0 vulnerabilities**.

## Test plan

- [x] `npm run test` — 29 files, 503 tests, all pass
- [x] `npm audit --omit=dev` — 0 findings (was 3)
- [ ] Reviewer: `npm ci && npm run test` to confirm reproducible

E2E (`test:e2e`) was attempted; failed with `Timed out waiting for step 1` across all PDF/Image specs. **Pre-existing** — same failures reproduce with this PR reverted. Not blocking; tracked separately.

## Security notes (R015)

- **Secrets:** none touched.
- **Auth/permissions:** N/A — Tauri capability allowlist unchanged; no IPC commands added; renderer trust boundary unchanged.
- **Remaining risks:** patched packages are dev/build tooling and don't ship in the bundled Tauri binary. The dev server is exposed during `npm run dev` so the patches matter for contributors. `@tailwindcss/vite` lives in `dependencies` rather than `devDependencies`, which is why prod-scope audit even sees these tools — hygiene issue worth filing separately, not a bump-introduced one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
