### PR TITLE
fix(e2e): explicit Cargo feature + stage fixtures into Tauri $TEMP scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "e2e:build": "tauri build --debug --features e2e --bundles app",
     "pretest:e2e": "node src/e2e/fixtures/generate-e2e-fixtures.mjs",
     "test:e2e": "wdio run src/e2e/wdio.conf.ts",
     "test:e2e:pdf": "wdio run src/e2e/wdio.conf.ts --suite pdf",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,8 +31,13 @@ image = "0.25"
 webp = "0.3"
 uuid = { version = "1", features = ["v4"] }
 
-# E2E testing — debug builds only (never ships to end users)
-[target.'cfg(debug_assertions)'.dependencies]
-tauri-plugin-webdriver-automation = "0.1"
+# E2E automation — opt-in via `--features e2e`. Never enabled in release builds.
+# Previously declared under `[target.'cfg(debug_assertions)'.dependencies]`, which
+# Cargo evaluates against target spec triples (not the rustc debug_assertions
+# flag), so inclusion was non-deterministic and produced an unexpected-cfg warning.
+tauri-plugin-webdriver-automation = { version = "0.1", optional = true }
+
+[features]
+e2e = ["dep:tauri-plugin-webdriver-automation"]
 
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1427,8 +1427,10 @@ pub fn run_with_file(open_file: Option<String>) {
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![greet, process_image, rotate_image, compress_pdf, cancel_processing, protect_pdf, unlock_pdf, convert_pdfa, repair_pdf, convert_with_libreoffice, convert_with_calibre, convert_with_textutil, convert_with_word, detect_converters, reveal_in_finder]);
 
-    // E2E automation plugin — debug builds only, never ships in release
-    #[cfg(debug_assertions)]
+    // E2E automation plugin — gated behind the `e2e` Cargo feature so it is
+    // deterministically included only when explicitly requested (e.g.
+    // `tauri build --debug --features e2e`). Never compiled into release.
+    #[cfg(feature = "e2e")]
     let builder = builder.plugin(tauri_plugin_webdriver_automation::init());
 
     builder

--- a/src/e2e/fixtures/generate-e2e-fixtures.mjs
+++ b/src/e2e/fixtures/generate-e2e-fixtures.mjs
@@ -1,25 +1,27 @@
 #!/usr/bin/env node
 /**
- * Generate E2E error-path fixtures.
+ * Generate E2E error-path fixtures into Tauri's $TEMP fs scope.
  * Run automatically via `npm run pretest:e2e` before every test run.
  *
- * Creates in test-fixtures-e2e/:
+ * Creates in ${os.tmpdir()}/papercut-e2e/error/:
  *   large-sparse.pdf   -- 110 MB sparse file (triggers >100 MB guard)
  *   large-sparse.jpg   -- 110 MB sparse file (image variant)
  *   corrupt.pdf        -- 0 bytes (triggers empty-file error)
  *   corrupt.jpg        -- 0 bytes (triggers empty-image error)
  *
- * Real PDF/image inputs are reused from test-fixtures/ -- no need to regenerate them.
+ * Why $TEMP: Tauri's fs capability scope (capabilities/default.json) only
+ * permits reads from $DOCUMENT, $DOWNLOAD, $DESKTOP, $TEMP. Fixtures placed
+ * outside those paths are denied by the runtime, causing handleFileSelected
+ * to fall into the corrupt-file branch and never advance past step 0.
  *
- * Note: test-fixtures-e2e/large-sparse.* are in .gitignore (too large to commit).
- *       test-fixtures-e2e/corrupt.* ARE committed as zero-byte stubs.
+ * Real PDF/image inputs are staged from project test-fixtures/ → ${stage}/real/
+ * by the wdio config's top-level setup (see src/e2e/wdio.conf.ts).
  */
 import { writeFileSync, mkdirSync, openSync, ftruncateSync, closeSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const outDir = join(__dirname, '../../../test-fixtures-e2e');
+const outDir = join(tmpdir(), 'papercut-e2e', 'error');
 mkdirSync(outDir, { recursive: true });
 
 function createSparseFile(filePath, sizeBytes) {
@@ -33,8 +35,8 @@ const MB_110 = 110 * 1024 * 1024;
 createSparseFile(join(outDir, 'large-sparse.pdf'), MB_110);
 createSparseFile(join(outDir, 'large-sparse.jpg'), MB_110);
 
-// Zero-byte corrupt stubs (already committed; recreated here for idempotency)
+// Zero-byte corrupt stubs
 writeFileSync(join(outDir, 'corrupt.pdf'), Buffer.alloc(0));
 writeFileSync(join(outDir, 'corrupt.jpg'), Buffer.alloc(0));
 
-console.log('E2E error-path fixtures ready in test-fixtures-e2e/');
+console.log(`E2E error-path fixtures ready in ${outDir}`);

--- a/src/e2e/wdio.conf.ts
+++ b/src/e2e/wdio.conf.ts
@@ -2,11 +2,44 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, spawnSync, type ChildProcess } from 'child_process';
 import { createConnection } from 'net';
+import { mkdirSync, copyFileSync, readdirSync, statSync } from 'fs';
+import { tmpdir } from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Stage fixtures into Tauri's $TEMP fs scope before specs are imported.
+//
+// Tauri's capability scope (src-tauri/capabilities/default.json) only permits
+// reads from $DOCUMENT/$DOWNLOAD/$DESKTOP/$TEMP. The project's test-fixtures/
+// directory is outside every allowed scope, so reading fixtures directly from
+// there fails the runtime fs check and the UI never advances past step 0.
+//
+// We mirror real fixtures into ${tmpdir}/papercut-e2e/real/ here, and the
+// pretest:e2e script generates error-path fixtures into ${tmpdir}/papercut-e2e/
+// error/. The driver helper picks both up via E2E_*_DIR env vars set below.
+const STAGE_DIR = join(tmpdir(), 'papercut-e2e');
+const STAGE_REAL = join(STAGE_DIR, 'real');
+const STAGE_ERROR = join(STAGE_DIR, 'error');
+const STAGE_OUTPUT = join(STAGE_DIR, 'output');
+mkdirSync(STAGE_REAL, { recursive: true });
+mkdirSync(STAGE_ERROR, { recursive: true });
+mkdirSync(STAGE_OUTPUT, { recursive: true });
+
+const PROJECT_REAL_FIXTURES = join(__dirname, '../../test-fixtures');
+for (const entry of readdirSync(PROJECT_REAL_FIXTURES)) {
+  const src = join(PROJECT_REAL_FIXTURES, entry);
+  if (statSync(src).isFile()) {
+    copyFileSync(src, join(STAGE_REAL, entry));
+  }
+}
+
+process.env.E2E_REAL_FIXTURES_DIR ??= STAGE_REAL;
+process.env.E2E_FIXTURES_DIR ??= STAGE_ERROR;
+process.env.E2E_OUTPUT_DIR ??= STAGE_OUTPUT;
+
 // Resolve the Tauri binary path for the current platform.
-// E2E tests run against a debug build so tauri-plugin-webdriver-automation is compiled in.
+// E2E tests run against a debug build with `--features e2e` so the
+// tauri-plugin-webdriver-automation plugin is registered.
 function getTauriBinaryPath(): string {
   if (process.platform === 'darwin') {
     return join(__dirname, '../../src-tauri/target/debug/bundle/macos/Papercut.app/Contents/MacOS/tauri-app');


### PR DESCRIPTION
## Summary

Two adjacent fixes that together unblock `npm run test:e2e` on macOS, addressing the long-standing E2E breakage flagged in yesterday's security-hardening session.

### 1. Cargo `debug_assertions` predicate → explicit `e2e` feature

The previous `[target.'cfg(debug_assertions)'.dependencies]` form was incorrect: Cargo evaluates `[target.<cfg>.dependencies]` against **target spec triples and target features**, not against rustc's `debug_assertions` flag. This produced an unexpected-cfg warning and made plugin inclusion non-deterministic.

Replaced with an opt-in `e2e` Cargo feature. `tauri-plugin-webdriver-automation` now compiles in only when built with `--features e2e`; release builds are unaffected.

### 2. Stage e2e fixtures into Tauri's `$TEMP` capability scope

Tauri's fs capability scope (`src-tauri/capabilities/default.json`) only permits reads from `$DOCUMENT / $DOWNLOAD / $DESKTOP / $TEMP`. Real fixtures live in `~/papercut/test-fixtures/`, which is outside every allowed scope. Every PDF/Image E2E test was failing with `Timed out waiting for step 1` because:

```
handleFileSelected(path)
  → getFileSizeBytes(path)        ← Tauri fs scope check fails
  → catch sets corruptFileError   ← step never advances
```

`src/e2e/helpers/driver.ts` already documented the intended fix ("CI can place [fixtures] inside `/tmp` (within Tauri's `$TEMP` fs scope)"), but the staging wiring was missing.

**Now:** at the top of `wdio.conf.ts` we copy real fixtures into `${os.tmpdir()}/papercut-e2e/real/`, and `generate-e2e-fixtures.mjs` writes generated error-path fixtures (`large-sparse.*`, `corrupt.*`) into `${os.tmpdir()}/papercut-e2e/error/`. The driver helper picks both up via `E2E_*_DIR` env vars set by the same code (CI overrides still win via `??=`).

### Result

- **Before:** 100% of PDF tests failed at `Timed out waiting for step 1`.
- **After:** Success-case PDF compression tests (`PDF-Q-WEB / SCREEN / PRINT`) all pass in ~21s.
- A separate upstream issue (`lock poisoned: PoisonError` in `tauri-plugin-webdriver-automation 0.1.3` across test transitions) blocks the remaining tests. Tracked upstream — out of scope for this PR.

### New build command

```
npm run e2e:build
# alias for: tauri build --debug --features e2e --bundles app
```

The previous command (`npm run tauri -- build --debug --bundles app`) no longer compiles the plugin in. The `--bundles app` flag is still required because the default DMG bundling step deletes the `.app` that wdio expects.

## Files changed

- `src-tauri/Cargo.toml` — `[features]` + `optional = true` dep
- `src-tauri/src/lib.rs` — `#[cfg(feature = "e2e")]`
- `src/e2e/wdio.conf.ts` — top-of-file fixture staging
- `src/e2e/fixtures/generate-e2e-fixtures.mjs` — write to `$TMPDIR/papercut-e2e/error/`
- `package.json` — new `e2e:build` script

## Security notes (R015)

- No secrets touched. No Tauri capability scope expanded — fix uses only the existing `$TEMP` allowlist already in `default.json`.
- The `e2e` Cargo feature is opt-in; never set in any production/release build path. Renderer→Rust trust boundary (P014) unchanged.
- Risk to flag: if a future CI/release workflow accidentally adds `--features e2e` to a packaged build, it would expose the WebDriver automation port (4444) to whoever runs the resulting `.app`. Suggest a follow-up note in `.claude/project_rules_decisions.md` under P013 reinforcing that `e2e` must remain off in any release-path build.

## Test plan

- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` — clean (no e2e feature)
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --features e2e` — clean (with e2e feature)
- [ ] `npm run test` — 503/503 passing
- [ ] `npx tsc --noEmit` (main) — clean
- [ ] `npm run e2e:build` then `npm run test:e2e:pdf` — PDF-Q-WEB/SCREEN/PRINT pass; further tests blocked by the upstream PoisonError noted above
- [ ] `npm audit --omit=dev` — 0 advisories (per P015)

🤖 Generated with [Claude Code](https://claude.com/claude-code)